### PR TITLE
Fixed listing numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ This bot was intented to run in [replit](https://replit.com) so my installation 
 
 1. Go to the Replit link for the project: https://replit.com/@GeorgeKhan/poke-guesser-bot
 
-3. Click Fork to fork it to your own Replit account.
+2. Click Fork to fork it to your own Replit account.
 
 ![replit-3](images/replit-3.png)
 
-4. Click the Secrets button (lock icon). Create a new secret with the key `TOKEN` and the value set to your Discord bot token. Click `Add new secret` to finish creating the secret. 
+3. Click the Secrets button (lock icon). Create a new secret with the key `TOKEN` and the value set to your Discord bot token. Click `Add new secret` to finish creating the secret. 
 
 ![replit-4](images/replit-4.png)
 
-5. Click the **Run** button at the top of the Replit page to start the bot.
+4. Click the **Run** button at the top of the Replit page to start the bot.
 
 ## Setup Discord Bot
 


### PR DESCRIPTION
On the page there was point 4 after the 2.
In the Source there was point 3 after point one. I hopefully fixed this. I cannot say it for sure because i don't know Markdown that well. Adding an Image what i wanted to fix:
![image](https://user-images.githubusercontent.com/30803034/130619538-5213e873-1e5e-4fab-8404-5271dd09bbea.png)
