### PR TITLE
Fixed the problem with the missing sprite

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,11 @@ function checkCommand(command, msg) {
       pokeFetch.fetchSprite(pokemon.url).then(sprites => {
         // Extract sprite and official artwork
         const spriteUrl = sprites.front_default;
+        if (!spriteUrl) {
+          console.log(`Redoing the explore because i got a ${pokemon.name} without a front sprite`);
+          checkCommand(command, msg);
+          return;
+        }
         const officialArtUrl = sprites.other['official-artwork'].front_default;
         console.log(spriteUrl);
         console.log(officialArtUrl);

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function checkCommand(command, msg) {
         // Extract sprite and official artwork
         const spriteUrl = sprites.front_default;
         if (!spriteUrl) {
-          console.log(`Redoing the explore because i got a ${pokemon.name} without a front sprite`);
+          console.log(`Warning: front_default sprite for ${pokemon.name} is null. Fetching new pokemon.`);
           checkCommand(command, msg);
           return;
         }


### PR DESCRIPTION
Fixed by adding a check if spriteUrl is null and calling checkCommand recursivly. The code i tested with is following:
![proof_code](https://user-images.githubusercontent.com/30803034/131249965-afbc73c9-97db-41e5-bbd1-623b52e76c3c.png)
I just set the name and url of the pokemon to force exploration of Togedemaru-totem and prevented it in the recursive call by updating a boolean.