### PR TITLE
Fixed problem with catching

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,11 +426,10 @@ function checkInput(inputRequest, msg) {
               \`$leaderboard\`: see the updated leaderboard`;
               util.embedReply(title, message, msg, artwork);
             });
-            
-            guessEntered = false;  // Reset guessEntered
             break; // To avoid scoring multiple times
           }
         }
+        guessEntered = false;  // Reset guessEntered
       });
     });
   }


### PR DESCRIPTION
Fixed the problem that the catch won't work if there was a wrong guess before.
Failure:
![Failure](https://cdn.discordapp.com/attachments/849665948427747398/904124479498772540/unknown.png)
Success:
![Success](https://cdn.discordapp.com/attachments/862014564392632401/904127701026222111/unknown.png)
Info: I had my test for simisear still active (hardcoding simisear)