### PR TITLE
Fix Crash in findUser

### DIFF
--- a/leaderboard.ts
+++ b/leaderboard.ts
@@ -30,7 +30,7 @@ export default class Leaderboard {
     // Add fields to Embed
     for (let i: number = 0; i < Math.max(5, scores.length); i++) {
       let userId = scores[i]?.getDataValue("userId");
-      let userObj = await Util.findUser(interaction, userId);
+      let userObj = userId ? await Util.findUser(interaction, userId) : null;
       if (userObj) {
         if (Array.isArray(userObj)) {
           userName = userObj[0].username;

--- a/util.ts
+++ b/util.ts
@@ -90,7 +90,7 @@ export default class Util {
   ): Promise<GuildMember | undefined> {
     // Return member or undefined if not found (force specifies if cache should be checked)
     // I could have omitted the force property, but i have put it there to make it clear
-    return await interaction.guild?.members?.fetch({ user: id, force: false });
+    return await interaction.guild?.members.fetch({ user: id, force: false });
   }
 
   // Finds the User by User-ID
@@ -98,12 +98,7 @@ export default class Util {
     interaction: BaseInteraction,
     id: string,
   ): Promise<User | undefined> {
-    let member = await this.findMember(interaction, id);
-    if (!member) {
-      console.log(`WARNING: User ID ${id} not found in guild.`);
-      return member;
-    }
-    return member.user;
+    return await interaction.client.users.fetch(id, { force: false });
   }
 
   static isAdmin(member: GuildMember): boolean {


### PR DESCRIPTION
This fixes the crash in the `findUser` function of `util.ts` when a Member it tries to fetch already left the server or their account was deleted. It also fixed a crash with the error message `Value "null" is not snowflake.` when fetching the user and there is no user to find in the database when loading the leaderboard without any user on it.

Fixes #113
