### PR TITLE
Fix Docker CI by making sure postgres can be reached

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: ["master", "main", "develop"]
   pull_request:
     branches: ["master", "main", "develop"]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,21 @@ RUN npm run build
 
 # Stage 2: Run
 FROM node:20.3-bookworm-slim
+# Add wait script
+COPY --from=ghcr.io/ufoscout/docker-compose-wait:latest /wait /wait
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/package.json .
 COPY --from=builder /usr/src/app/package-lock.json .
 COPY --from=builder /usr/src/app/build .
 COPY --from=builder /usr/src/app/src/languages ./languages
 RUN npm ci --omit=dev
-CMD [ "npm", "run", "start" ]
+ENV WAIT_COMMAND="npm start"
+# comma separated list of pairs host:port for which you want to wait.
+ENV WAIT_HOSTS=db:5432
+# max number of seconds to wait for all the hosts to be available before failure. The default is 30 seconds.
+ENV WAIT_TIMEOUT=300
+# number of seconds to sleep between retries. The default is 1 second.
+ENV WAIT_SLEEP_INTERVAL=5
+# The timeout of a single TCP connection to a remote host before attempting a new connection. The default is 5 seconds.
+ENV WAIT_HOST_CONNECT_TIMEOUT=30
+ENTRYPOINT ["/wait"]


### PR DESCRIPTION
Changes in this PR:
- Add `workflow_dispatch` trigger to be able to trigger the docker image workflow manually
- Add docker sleep tool to wait for the postgres container to be reachable

References:
https://www.datanovia.com/en/lessons/docker-compose-wait-for-container-using-wait-tool/docker-compose-wait-for-postgres-container-to-be-ready/
https://github.com/ufoscout/docker-compose-wait