### PR TITLE
Update docker (base) images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:20.12-bookworm-slim as builder
+FROM node:22.1-bookworm-slim as builder
 WORKDIR /usr/src/app
 COPY package.json .
 COPY package-lock.json .
@@ -9,7 +9,7 @@ RUN npm ci
 RUN npm run build
 
 # Stage 2: Run
-FROM node:20.12-bookworm-slim
+FROM node:22.1-bookworm-slim
 # Add wait script
 COPY --from=ghcr.io/ufoscout/docker-compose-wait:latest /wait /wait
 WORKDIR /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   db:
-    image: postgres:15.3
+    image: postgres:16.2-bookworm
     container_name: poke-guesser-postgres
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
NodeJS 22 will be the next LTS version and Postgres just supports each version for 5 years. I think while it is not in production yet, it makes sense to stay at the bleeding edge.