### PR TITLE
Add Deno ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+  - package-ecosystem: "deno" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
GitHub recently added support for Deno to Dependabot. Let's use it.