### PR TITLE
Use actual folder for the postgres volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docker.env
 node_modules/
 build/
 *.js
+data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - default
     volumes:
       - ${PWD}/docker-sql-init.sql:/docker-entrypoint-initdb.d/init.sql
-      - database:/var/lib/postgresql/data
+      - ./data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
@@ -28,7 +28,5 @@ services:
       - ./docker.env
     networks:
       - default
-volumes:
-  database:
 networks:
   default:


### PR DESCRIPTION
Instead of using a volume that cannot really be managed outside of docker, bind to an actual folder on the host filesystem.